### PR TITLE
pull already-built kmods and remove from list 

### DIFF
--- a/.github/workflows/check-and-build.yaml
+++ b/.github/workflows/check-and-build.yaml
@@ -21,3 +21,4 @@ jobs:
         run: python scripts/check_changes.py
         env:
           TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ARTIFACT_TOKEN: ${{ secrets.ARTIFACT_TOKEN }}

--- a/argfile.conf
+++ b/argfile.conf
@@ -12,3 +12,4 @@ DRIVER_REPO=https://github.com/NVIDIA/open-gpu-kernel-modules.git
 DRIVER_VERSION=570.86.15
 DRIVER_VENDOR=nvidia-opengpu
 UPLOAD_ARTIFACT_REPO=gitlab.com/ebelarte/artifact-storage.git
+UPLOAD_ARTIFACT_REPO_API=https://gitlab.com/api/v4/projects/66831545/repository/tree


### PR DESCRIPTION
check the UPLOAD_ARTIFACT_REPO repo for already-built kmods and only build ones that dont exist there.

it also adds a "debug" cli arg so you can run "python scripts/check_changes.py debug"  and it will do everything but NOT mess with the repo  (i.e. not the git commands)

I also ran pylint over the code which resulted in some minor changes (imports being moved, that sort of thing)

known issues:
- it only checks the name of the kmod, not the md5sum or similar so if for some reason the code changes and not the driver version number nothing gets rebuilt
- this is set up for gitlab, and probably wont work for any other repo as yet
- it no longer checks the DRIVER_PUBLISHED field in data/combined_output.json , I'm not sure if this is a good thing or not
- it needs a secret in the github workflow for the gitlab api,   which I haven't setup yet

and probably other stuff I haven't thought of yet